### PR TITLE
Fix RDS connection + Reference errors

### DIFF
--- a/environments/aws/dns.tf
+++ b/environments/aws/dns.tf
@@ -62,6 +62,6 @@ resource "helm_release" "external_dns" {
 }
 
 output "aws_acm_certificate" {
-  value = [aws_acm_certificate.fthw_demo.arn]
+  value = [aws_acm_certificate.flyte_cert.arn]
 
 }

--- a/environments/aws/rds.tf
+++ b/environments/aws/rds.tf
@@ -14,8 +14,8 @@ module "flyte_db" {
   subnets             = module.vpc.database_subnets
   vpc_id              = module.vpc.vpc_id
 
-  database_name          = "flyteadmin"
-  master_username        = "flyteadmin"
+  database_name          = "app"
+  master_username        = "postgres"
   
 #Comment to disable random password generation for the DB
   random_password_length = 63

--- a/environments/aws/s3.tf
+++ b/environments/aws/s3.tf
@@ -10,6 +10,6 @@ module "flyte_data" {
 }
 
 output "bucket" {
-  value = module.flyte_data.bucket.name
+  value = module.flyte_data.s3_bucket_id
   sensitive = false
 }


### PR DESCRIPTION
Fixed miss alignment between TF RDS credentials and the helm defaults (also the rest of the guide)

**Fixed both reference errors in**
- Certificate - pointed to an unknown certificate.
- Bucket - used a wrong referencing structure.