### PR TITLE
GCP Cloud SQL database and usernames should be "flyteadmin"

### DIFF
--- a/environments/gcp/flyte-core/sql.tf
+++ b/environments/gcp/flyte-core/sql.tf
@@ -12,7 +12,7 @@ module "flyte-db" {
   
   additional_databases = [
     {
-      name      = "flyte"
+      name      = "flyteadmin"
       charset   = ""
       collation = ""
     }
@@ -20,7 +20,7 @@ module "flyte-db" {
 
   additional_users = [
     {
-      name            = "flyte"
+      name            = "flyteadmin"
       password        = ""
       random_password = true
     }


### PR DESCRIPTION
...so as to match the default values in `flyte-db`