### PR TITLE
Fixes Azure init behavior

### DIFF
--- a/environments/azure/flyte-core/README.md
+++ b/environments/azure/flyte-core/README.md
@@ -26,12 +26,13 @@ The modules in this repo have been tested with Terraform and OpenTofu, and will 
     - Resource Group
     - Storage account with default settings
     - Storage container for the Terraform state
-- Put these values into [backend.tfvars](./backend.tfvars)
+- Put these values into [backend.tf](./backend.tf)
 
 # Update locals values
 
 - Go to [locals.tf](./locals.tf) and update the values to match your desired configuration.
 
+- To automatically provide the input variables that the module needs you can uncomment and edit the values on [terraform.tfvars](./terraform.tfvars) 
 
 # Create Cluster & Cluster Resources
 1. From the `environments/azure/flyte-core` folder, initialize the Terraform backend:

--- a/environments/azure/flyte-core/aks.tf
+++ b/environments/azure/flyte-core/aks.tf
@@ -31,7 +31,7 @@ resource "azurerm_kubernetes_cluster" "flyte" {
     node_count          = 1
     min_count           = 1
     max_count           = 10
-    enable_auto_scaling = true
+    auto_scaling_enabled = true
   }
 
   identity {
@@ -52,7 +52,7 @@ depends_on = [ azurerm_kubernetes_cluster.flyte ]
 name = "gpupool"
 kubernetes_cluster_id = azurerm_kubernetes_cluster.flyte.id
 node_count = local.gpu_settings.gpu_node_pool_count
-enable_auto_scaling = true
+auto_scaling_enabled  = true
 min_count           = local.gpu_settings.gpu_node_pool_min_count
 max_count           = local.gpu_settings.gpu_node_pool_max_count
 vm_size             = local.gpu_settings.gpu_machine_type

--- a/environments/azure/flyte-core/backend.tf
+++ b/environments/azure/flyte-core/backend.tf
@@ -1,0 +1,10 @@
+# https://www.terraform.io/language/settings/backends/azurerm
+#Change the following values to match your environment
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "flyte-deploy"
+    storage_account_name = "fdtfstate"
+    container_name       = "tfstate"
+    key                  = "flyte-on-azure/terraform.tfstate"
+  }
+}

--- a/environments/azure/flyte-core/backend.tfvars
+++ b/environments/azure/flyte-core/backend.tfvars
@@ -1,6 +1,0 @@
-#Change the following values to match your environment
-resource_group_name  = "flyte-deploy" 
-storage_account_name = "fdtfstate"
-container_name       = "tfstate" #Storage container to store state
-
-key                  = "flyte-on-azure/terraform.tfstate"

--- a/environments/azure/flyte-core/providers.tf
+++ b/environments/azure/flyte-core/providers.tf
@@ -10,8 +10,7 @@ terraform {
       version = ">= 1.14.0"
     }
   }
-  # https://www.terraform.io/language/settings/backends/azurerm
-  backend "azurerm" {}
+  
 }
 
 provider "kubectl" {

--- a/environments/azure/flyte-core/storage.tf
+++ b/environments/azure/flyte-core/storage.tf
@@ -1,7 +1,12 @@
 
 
+resource "random_string" "storage_account_suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
 resource "azurerm_storage_account" "flyte" {
-  name                          = "${local.tenant}${local.environment}"
+  name                          = "${local.tenant}${local.environment}${random_string.storage_account_suffix.result}"
   resource_group_name           = azurerm_resource_group.flyte.name
   location                      = azurerm_resource_group.flyte.location
   account_tier                  = "Standard"


### PR DESCRIPTION
Configuration errors on the backend block could lead to additional steps at deploy time. 

This PR introduces

1. Random suffix for the SA name, to mitigate possible name collisions
2. Updates the autoscaling parameter of the node pool to `auto_scaling_enabled` ([source](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#auto_scaling_enabled))
3. Updated instructions for the `init` step