### PR TITLE
Fix: Allow flytepropeller to list google cloud storage objects for distributed task error handling

### DIFF
--- a/environments/gcp/flyte-core/iam.tf
+++ b/environments/gcp/flyte-core/iam.tf
@@ -58,6 +58,7 @@ resource "google_project_iam_custom_role" "custom_IAM_roles" {
       "storage.objects.create",
       "storage.objects.delete",
       "storage.objects.get",
+      "storage.objects.list",
       "storage.objects.getIamPolicy",
       "storage.objects.update",
     ],


### PR DESCRIPTION
With the 1.14 release, flytepropeller is able to identify the root cause error in distributed tasks like pytorch jobs by aggregating error information from all workers and identifying the error that occurred first. See RFC https://github.com/flyteorg/flyte/pull/5598.

To do this, flytepropeller needs to list the error files from the different workers in the so called *raw output prefix* bucket of the respective execution.

In GCP, a specific permission for listing objects in buckets needs to be added to the custom IAM role for Flyte propeller.

---

I unfortunately don’t have access to an AWS and Azure environment to test whether changes are required there as well but from what I can see in the documentation, no changes should be required:

AWS:

> […] the s3:ListBucket permission (assigned by the IaC in this repo) allows the user to use the Amazon S3 ListObjectsV2 operation. ([source](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-policy-language-overview.html))

> [The ListObjectsV2 operation] returns some or all (up to 1,000) of the objects in a bucket with each request. ([source](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html))

Azure:

The azure module assign the broad `Storage Blob Data Owner` role:

> Provides full access to Azure Storage blob containers and data ([source](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-owner))




